### PR TITLE
Handle multiple email addresses

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -89,11 +89,14 @@ Ldap.findOrCreateFromLDAP = function(options, core, ldapEntry, callback) {
 Ldap.createLdapUser = function(core, options, ldapEntry, callback) {
     var User = mongoose.model('User');
     var field_mappings = options.field_mappings;
+    var ldapEmail = ldapEntry[field_mappings.email];
+    var email = ldapEmail.toString().split(',')[0];
+
     var data = {
         uid: ldapEntry[field_mappings.uid],
         username: ldapEntry[field_mappings.username] ||
                   ldapEntry[field_mappings.uid],
-        email: ldapEntry[field_mappings.email],
+        email: email,
         firstName: ldapEntry[field_mappings.firstName],
         lastName: ldapEntry[field_mappings.lastName],
         displayName: ldapEntry[field_mappings.displayName]


### PR DESCRIPTION
Some LDAP configurations will store several email addresses in the LDAP `email` field. This is the case of [Yunohost](http://yunohost.org/) setups, for instance.

Addresses are comma-separated (like `example@gmail.com,foo@bar.com`). For now `lets-chat-ldap` attempts to create a user with all these email addresses, which crashes the server.

This PR allow to take only the first address, and to ignore the other ones.
